### PR TITLE
Add explicit warning about global aliases

### DIFF
--- a/lib/aliased.pm
+++ b/lib/aliased.pm
@@ -196,6 +196,14 @@ use the new module by only changing one line of code.
   use aliased "New::Module::Name" => "Old::Module::Name";
   my $thing = Old::Module::Name->new;
 
+If you in two different packages alias like in the above example and use the
+same name for aliasing to, you will get a warning similar to the following:
+
+  Constant subroutine Old::Module::Name redefined at .../aliased.pm
+
+This is due to namespaced aliases being global, and are one of the reasons why
+you should try to avoid that kind of aliasing.
+
 =head2 Import Lists
 
 Sometimes, even with an OO module, you need to specify extra arguments when


### PR DESCRIPTION
For clarity I added an explicit warning about what you'll see if you use namespaced aliases defined similarly in two different packages. The reason is that I spent a little while trying to figure out why I saw that warning, and it was not after a couple of helpful people on IRC helped out that I found out what my mistake was. I am hoping this extra bit of documentation will help someone else doing the same silly thing, and hopefully save them some time debugging.
